### PR TITLE
Fikset link til nettside (Website-Hub/Portfolio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <hr>
 <details open>
   <summary><h2>Active Projects <img height="25px" src="https://github.com/unicfoxx/unicfoxx/blob/main/Images/emojisalute.png"></h2></summary>
-  <p>🔗Portfolio Website: <a href="https://unicfoxx.com">Website-Hub</a></p>
+  <p>🔗Portfolio Website: <a href="https://unicfoxx.github.io/Portfolio/">Portfolio</a></p>
 </details>
 <hr>
 <details open>


### PR DESCRIPTION
Det var link til `unicfoxx.com`, men som jeg har skjønt er vel den deaktivert og blir ikke hostet lenger - derfor har jeg endret til `https://unicfoxx.github.io/Portfolio/`